### PR TITLE
feat: activate forced txs, disallow bridging

### DIFF
--- a/packages/contracts-bedrock/foundry.toml
+++ b/packages/contracts-bedrock/foundry.toml
@@ -55,6 +55,7 @@ fs_permissions = [
   { access='read-write', path='./snapshots/' },
   { access='read-write', path='./deployments/' },
   { access='read', path='./deploy-config/' },
+  { access='read', path='./scripts/upgrade/input.json'},
   { access='read', path='./deploy-config-periphery/' },
   { access='read', path='./broadcast/' },
   { access='read', path = './forge-artifacts/' },

--- a/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
@@ -28,7 +28,12 @@ contract UpgradeOptimismPortal2 is Script {
         address newImpl = address(new OptimismPortal2(proofMaturityDelaySeconds, disputeGameFinalityDelaySeconds));
 
         // upgrade proxy
-        ProxyAdmin(proxyAdmin).upgrade(payable(optimismPortalProxy), newImpl);
+        bytes memory payload = abi.encodeCall(ProxyAdmin.upgrade, (payable(optimismPortalProxy), newImpl));
+        console.log("payload to be sent to: ", proxyAdmin);
+        console.logBytes(payload);
+
+        // for testing
+        // ProxyAdmin(proxyAdmin).upgrade(payable(optimismPortalProxy), newImpl);
 
         vm.stopBroadcast();
     }

--- a/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
@@ -5,10 +5,6 @@ import { Script, stdJson, console2 as console } from "forge-std/Script.sol";
 
 import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
-import { GameType } from "src/dispute/lib/Types.sol";
-import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
-import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 
 contract UpgradeOptimismPortal2 is Script {
     using stdJson for string;

--- a/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
+++ b/packages/contracts-bedrock/scripts/upgrade/OptimismPortal2_Upgrade.s.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Script, stdJson, console2 as console } from "forge-std/Script.sol";
+
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
+import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
+import { GameType } from "src/dispute/lib/Types.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+
+contract UpgradeOptimismPortal2 is Script {
+    using stdJson for string;
+
+    function run() external {
+        // owner of ProxyAdmin is needed
+        uint256 deployerPrivateKey = vm.promptSecretUint("PRIVATE_KEY");
+
+        string memory input = vm.readFile("scripts/upgrade/input.json");
+        string memory chainIdSlug = string(abi.encodePacked('["', vm.toString(block.chainid), '"]'));
+        address optimismPortalProxy = input.readAddress(string.concat(chainIdSlug, ".optimismPortalProxy"));
+        address proxyAdmin = input.readAddress(string.concat(chainIdSlug, ".proxyAdmin"));
+
+        OptimismPortal2 oldOp2 = OptimismPortal2(payable(optimismPortalProxy));
+        uint256 proofMaturityDelaySeconds = oldOp2.proofMaturityDelaySeconds();
+        uint256 disputeGameFinalityDelaySeconds = oldOp2.disputeGameFinalityDelaySeconds();
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy new implementation
+        address newImpl = address(new OptimismPortal2(proofMaturityDelaySeconds, disputeGameFinalityDelaySeconds));
+
+        // upgrade proxy
+        ProxyAdmin(proxyAdmin).upgrade(payable(optimismPortalProxy), newImpl);
+
+        vm.stopBroadcast();
+    }
+}

--- a/packages/contracts-bedrock/scripts/upgrade/input.json
+++ b/packages/contracts-bedrock/scripts/upgrade/input.json
@@ -3,7 +3,7 @@
       "optimismPortalProxy": "0x250D30c523104bf0a06825e7eAdE4Dc46EdfE40E",
       "proxyAdmin": "0x19DbD16f0a8e706D817B7e3b7bcF72917Ebb8832"
   },
-  "737373": {
+  "11155111": {
       "optimismPortalProxy": "0x456ea98d6dc12292be5e344637cb9de7cab396ce",
       "proxyAdmin": "0xf19ccf0C702589fA60565690b90B53293B9750Df"
   },

--- a/packages/contracts-bedrock/scripts/upgrade/input.json
+++ b/packages/contracts-bedrock/scripts/upgrade/input.json
@@ -3,6 +3,10 @@
       "optimismPortalProxy": "0x250D30c523104bf0a06825e7eAdE4Dc46EdfE40E",
       "proxyAdmin": "0x19DbD16f0a8e706D817B7e3b7bcF72917Ebb8832"
   },
+  "737373": {
+      "optimismPortalProxy": "0x456ea98d6dc12292be5e344637cb9de7cab396ce",
+      "proxyAdmin": "0xf19ccf0C702589fA60565690b90B53293B9750Df"
+  },
   "271828": {
       "optimismPortalProxy": "0xaf8117e94e4dd0501c119d3999876b8c0d53030a",
       "proxyAdmin": "0x388d733521b7BAcBA44f666152a1dc10ad53DFbC"

--- a/packages/contracts-bedrock/scripts/upgrade/input.json
+++ b/packages/contracts-bedrock/scripts/upgrade/input.json
@@ -1,0 +1,10 @@
+{
+  "1": {
+      "optimismPortalProxy": "0x250D30c523104bf0a06825e7eAdE4Dc46EdfE40E",
+      "proxyAdmin": "0x19DbD16f0a8e706D817B7e3b7bcF72917Ebb8832"
+  },
+  "271828": {
+      "optimismPortalProxy": "0xaf8117e94e4dd0501c119d3999876b8c0d53030a",
+      "proxyAdmin": "0x388d733521b7BAcBA44f666152a1dc10ad53DFbC"
+  }
+}

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -178,9 +178,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 3.14.0
+    /// @custom:semver 3.15.0
     function version() public pure virtual returns (string memory) {
-        return "3.14.0";
+        return "3.15.0";
     }
 
     /// @notice Constructs the OptimismPortal contract.
@@ -454,7 +454,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         payable
         metered(_gasLimit)
     {
-        require(false, "Deposit transactions are disabled");
+        // Disabling ETH bridging
+        require(msg.value == 0 && _value == 0, "Briding ETH is disabled");
+
+        // Disabling token bridging
+        require(msg.sender != systemConfig.l1StandardBridge() && msg.sender != systemConfig.l1ERC721Bridge(), "Briding tokens is disabled");
+
         // Just to be safe, make sure that people specify address(0) as the target when doing
         // contract creations.
         if (_isCreation && _to != address(0)) revert BadTarget();

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -455,10 +455,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         metered(_gasLimit)
     {
         // Disabling ETH bridging
-        require(msg.value == 0, "Briding ETH is disabled");
+        require(msg.value == 0, "Bridging ETH is disabled");
 
         // Disabling token bridging
-        require(msg.sender != systemConfig.l1StandardBridge() && msg.sender != systemConfig.l1ERC721Bridge(), "Briding tokens is disabled");
+        require(msg.sender != systemConfig.l1StandardBridge() && msg.sender != systemConfig.l1ERC721Bridge(), "Bridging tokens is disabled");
 
         // Just to be safe, make sure that people specify address(0) as the target when doing
         // contract creations.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -455,7 +455,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
         metered(_gasLimit)
     {
         // Disabling ETH bridging
-        require(msg.value == 0 && _value == 0, "Briding ETH is disabled");
+        require(msg.value == 0, "Briding ETH is disabled");
 
         // Disabling token bridging
         require(msg.sender != systemConfig.l1StandardBridge() && msg.sender != systemConfig.l1ERC721Bridge(), "Briding tokens is disabled");

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -180,7 +180,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ISemver {
     /// @notice Semantic version.
     /// @custom:semver 3.15.0
     function version() public pure virtual returns (string memory) {
-        return "3.15.0";
+        return "agg3.15.0";
     }
 
     /// @notice Constructs the OptimismPortal contract.

--- a/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1ERC721Bridge.t.sol
@@ -284,7 +284,7 @@ contract L1ERC721Bridge_Test is CommonTest {
     }
 
     /// @dev Tests that the ERC721 bridge successfully finalizes a withdrawal.
-    function test_finalizeBridgeERC721_succeeds() external {
+    function skip_test_finalizeBridgeERC721_succeeds() external {
         // Bridge the token.
         vm.prank(alice, alice);
         l1ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -162,7 +162,7 @@ contract L1StandardBridge_Initialize_TestFail is CommonTest { }
 
 contract L1StandardBridge_Receive_Test is CommonTest {
     /// @dev Tests receive bridges ETH successfully.
-    function test_receive_succeeds() external {
+    function skip_test_receive_succeeds() external {
         uint256 balanceBefore = address(optimismPortal2).balance;
 
         // The legacy event must be emitted for backwards compatibility
@@ -264,7 +264,7 @@ contract L1StandardBridge_DepositETH_Test is PreBridgeETH {
     ///      Calls depositTransaction on the OptimismPortal.
     ///      Only EOA can call depositETH.
     ///      ETH ends up in the optimismPortal.
-    function test_depositETH_fromEOA_succeeds() external {
+    function skip_test_depositETH_fromEOA_succeeds() external {
         _preBridgeETH({ isLegacy: true, value: 500 });
         uint256 balanceBefore = address(optimismPortal2).balance;
         l1StandardBridge.depositETH{ value: 500 }(50000, hex"dead");
@@ -272,7 +272,7 @@ contract L1StandardBridge_DepositETH_Test is PreBridgeETH {
     }
 
     /// @dev Tests that depositing ETH succeeds for an EOA using 7702 delegation.
-    function test_depositETH_fromEOA7702_succeeds() external {
+    function skip_test_depositETH_fromEOA7702_succeeds() external {
         // Set alice to have 7702 code.
         vm.etch(alice, abi.encodePacked(hex"EF0100", address(0)));
 
@@ -299,7 +299,7 @@ contract L1StandardBridge_BridgeETH_Test is PreBridgeETH {
     ///      Calls depositTransaction on the OptimismPortal.
     ///      Only EOA can call bridgeETH.
     ///      ETH ends up in the optimismPortal.
-    function test_bridgeETH_succeeds() external {
+    function skip_test_bridgeETH_succeeds() external {
         _preBridgeETH({ isLegacy: false, value: 500 });
         uint256 balanceBefore = address(optimismPortal2).balance;
         l1StandardBridge.bridgeETH{ value: 500 }(50000, hex"dead");
@@ -379,7 +379,7 @@ contract L1StandardBridge_DepositETHTo_Test is PreBridgeETHTo {
     ///      Calls depositTransaction on the OptimismPortal.
     ///      EOA or contract can call depositETHTo.
     ///      ETH ends up in the optimismPortal.
-    function test_depositETHTo_succeeds() external {
+    function skip_test_depositETHTo_succeeds() external {
         _preBridgeETHTo({ isLegacy: true, value: 600 });
         uint256 balanceBefore = address(optimismPortal2).balance;
         l1StandardBridge.depositETHTo{ value: 600 }(bob, 60000, hex"dead");
@@ -393,7 +393,7 @@ contract L1StandardBridge_BridgeETHTo_Test is PreBridgeETHTo {
     ///      Calls depositTransaction on the OptimismPortal.
     ///      Only EOA can call bridgeETHTo.
     ///      ETH ends up in the optimismPortal.
-    function test_bridgeETHTo_succeeds() external {
+    function skip_test_bridgeETHTo_succeeds() external {
         _preBridgeETHTo({ isLegacy: false, value: 600 });
         uint256 balanceBefore = address(optimismPortal2).balance;
         l1StandardBridge.bridgeETHTo{ value: 600 }(bob, 60000, hex"dead");

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -22,6 +22,7 @@ import "src/libraries/PortalErrors.sol";
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
@@ -164,7 +165,7 @@ contract OptimismPortal2_Test is CommonTest {
     function test_depositTransaction_contractCreation_reverts() external {
         // contract creation must have a target of address(0)
         vm.expectRevert(BadTarget.selector);
-        optimismPortal2.depositTransaction(address(1), 1, 0, true, hex"");
+        optimismPortal2.depositTransaction(address(1), 0, 0, true, hex"");
     }
 
     /// @dev Tests that `depositTransaction` reverts when the data is too large.
@@ -187,6 +188,18 @@ contract OptimismPortal2_Test is CommonTest {
         vm.expectRevert(SmallGasLimit.selector);
         optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
     }
+
+    /// @dev Test that `depositTransaction` reverts when the sender is the L1 Standard Bridge or L1 ERC721 Bridge.
+    function test_depositTransaction_bridging_reverts() external {
+        vm.prank(systemConfig.l1StandardBridge());
+        vm.expectRevert("Briding tokens is disabled");
+        optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
+
+        vm.prank(systemConfig.l1ERC721Bridge());
+        vm.expectRevert("Briding tokens is disabled");
+        optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
+    }
+
 
     /// @dev Tests that `depositTransaction` succeeds for small,
     ///      but sufficient, gas limits.
@@ -236,7 +249,10 @@ contract OptimismPortal2_Test is CommonTest {
         if (_isCreation) _to = address(0);
 
         uint256 balanceBefore = address(optimismPortal2).balance;
-        _mint = bound(_mint, 0, type(uint256).max - balanceBefore);
+
+        // always 0, no ETH transfers allowed
+        _mint = 0;
+        _value = 0;
 
         // EOA emulation
         vm.expectEmit(address(optimismPortal2));
@@ -284,7 +300,8 @@ contract OptimismPortal2_Test is CommonTest {
         if (_isCreation) _to = address(0);
 
         uint256 balanceBefore = address(optimismPortal2).balance;
-        _mint = bound(_mint, 0, type(uint256).max - balanceBefore);
+        _mint = 0;
+        _value = 0;
 
         // EOA emulation
         vm.expectEmit(address(optimismPortal2));
@@ -334,7 +351,8 @@ contract OptimismPortal2_Test is CommonTest {
         if (_isCreation) _to = address(0);
 
         uint256 balanceBefore = address(optimismPortal2).balance;
-        _mint = bound(_mint, 0, type(uint256).max - balanceBefore);
+        _mint = 0;
+        _value = 0;
 
         vm.expectEmit(address(optimismPortal2));
         emitTransactionDeposited({

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -22,7 +22,6 @@ import "src/libraries/PortalErrors.sol";
 // Interfaces
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
-import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
@@ -136,7 +135,7 @@ contract OptimismPortal2_Test is CommonTest {
     }
 
     /// @dev Tests that `receive` successdully deposits ETH.
-    function testFuzz_receive_succeeds(uint256 _value) external {
+    function skip_testFuzz_receive_succeeds(uint256 _value) external {
         uint256 balanceBefore = address(optimismPortal2).balance;
         _value = bound(_value, 0, type(uint256).max - balanceBefore);
 
@@ -192,11 +191,11 @@ contract OptimismPortal2_Test is CommonTest {
     /// @dev Test that `depositTransaction` reverts when the sender is the L1 Standard Bridge or L1 ERC721 Bridge.
     function test_depositTransaction_bridging_reverts() external {
         vm.prank(systemConfig.l1StandardBridge());
-        vm.expectRevert("Briding tokens is disabled");
+        vm.expectRevert("Bridging tokens is disabled");
         optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
 
         vm.prank(systemConfig.l1ERC721Bridge());
-        vm.expectRevert("Briding tokens is disabled");
+        vm.expectRevert("Bridging tokens is disabled");
         optimismPortal2.depositTransaction({ _to: address(1), _value: 0, _gasLimit: 0, _isCreation: false, _data: hex"" });
     }
 

--- a/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2CrossDomainMessenger.t.sol
@@ -44,7 +44,7 @@ contract L2CrossDomainMessenger_Test is CommonTest {
     }
 
     /// @dev Tests that `sendMessage` executes successfully.
-    function test_sendMessage_succeeds() external {
+    function test_sendMessage_fails() external {
         bytes memory xDomainCallData =
             Encoding.encodeCrossDomainMessage(l2CrossDomainMessenger.messageNonce(), alice, recipient, 0, 100, hex"ff");
         vm.expectCall(
@@ -55,26 +55,7 @@ contract L2CrossDomainMessenger_Test is CommonTest {
             )
         );
 
-        // MessagePassed event
-        vm.expectEmit(true, true, true, true);
-        emit MessagePassed(
-            l2ToL1MessagePasser.messageNonce(),
-            address(l2CrossDomainMessenger),
-            address(l1CrossDomainMessenger),
-            0,
-            l2CrossDomainMessenger.baseGas(hex"ff", 100),
-            xDomainCallData,
-            Hashing.hashWithdrawal(
-                Types.WithdrawalTransaction({
-                    nonce: l2ToL1MessagePasser.messageNonce(),
-                    sender: address(l2CrossDomainMessenger),
-                    target: address(l1CrossDomainMessenger),
-                    value: 0,
-                    gasLimit: l2CrossDomainMessenger.baseGas(hex"ff", 100),
-                    data: xDomainCallData
-                })
-            )
-        );
+        vm.expectRevert("Withdrawals are disabled");
 
         vm.prank(alice);
         l2CrossDomainMessenger.sendMessage(recipient, hex"ff", uint32(100));
@@ -82,7 +63,7 @@ contract L2CrossDomainMessenger_Test is CommonTest {
 
     /// @dev Tests that `sendMessage` can be called twice and that
     ///      the nonce increments correctly.
-    function test_sendMessage_twice_succeeds() external {
+    function skip_test_sendMessage_twice_succeeds() external {
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
         l2CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));
         l2CrossDomainMessenger.sendMessage(recipient, hex"aa", uint32(500_000));

--- a/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ERC721Bridge.t.sol
@@ -87,7 +87,7 @@ contract L2ERC721Bridge_Test is CommonTest {
 
     /// @dev Tests that `bridgeERC721` correctly bridges a token and
     ///      burns it on the origin chain.
-    function test_bridgeERC721_succeeds() public {
+    function skip_test_bridgeERC721_succeeds() public {
         // Expect a call to the messenger.
         vm.expectCall(
             address(l2CrossDomainMessenger),
@@ -164,7 +164,7 @@ contract L2ERC721Bridge_Test is CommonTest {
 
     /// @dev Tests that `bridgeERC721To` correctly bridges a token
     ///      and burns it on the origin chain.
-    function test_bridgeERC721To_succeeds() external {
+    function skip_test_bridgeERC721To_succeeds() external {
         // Expect a call to the messenger.
         vm.expectCall(
             address(l2CrossDomainMessenger),
@@ -236,7 +236,7 @@ contract L2ERC721Bridge_Test is CommonTest {
     }
 
     /// @dev Tests that `finalizeBridgeERC721` correctly finalizes a bridged token.
-    function test_finalizeBridgeERC721_succeeds() external {
+    function skip_test_finalizeBridgeERC721_succeeds() external {
         // Bridge the token.
         vm.prank(alice, alice);
         l2ERC721Bridge.bridgeERC721(address(localToken), address(remoteToken), tokenId, 1234, hex"5678");
@@ -260,7 +260,7 @@ contract L2ERC721Bridge_Test is CommonTest {
 
     /// @dev Tests that `finalizeBridgeERC721` reverts if the token is not compliant
     ///      with the `IOptimismMintableERC721` interface.
-    function test_finalizeBridgeERC721_interfaceNotCompliant_reverts() external {
+    function skip_test_finalizeBridgeERC721_interfaceNotCompliant_reverts() external {
         // Create a non-compliant token
         NonCompliantERC721 nonCompliantToken = new NonCompliantERC721(alice);
 

--- a/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2StandardBridge.t.sol
@@ -59,7 +59,7 @@ contract L2StandardBridge_Test is CommonTest {
     }
 
     /// @dev Tests that the bridge receives ETH and successfully initiates a withdrawal.
-    function test_receive_succeeds() external {
+    function skip_test_receive_succeeds() external {
         assertEq(address(l2ToL1MessagePasser).balance, 0);
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
 
@@ -156,7 +156,7 @@ contract L2StandardBridge_Test is CommonTest {
 
     /// @dev Tests that the legacy `withdraw` interface on the L2StandardBridge
     ///      successfully initiates a withdrawal.
-    function test_withdraw_ether_succeeds() external {
+    function skip_test_withdraw_ether_succeeds() external {
         assertTrue(alice.balance >= 100);
         assertEq(Predeploys.L2_TO_L1_MESSAGE_PASSER.balance, 0);
 
@@ -270,7 +270,7 @@ contract L2StandardBridge_BridgeERC20_Test is PreBridgeERC20 {
     // - token is burned
     // - emits WithdrawalInitiated
     // - calls Withdrawer.initiateWithdrawal
-    function test_withdraw_withdrawingERC20_succeeds() external {
+    function skip_test_withdraw_withdrawingERC20_succeeds() external {
         _preBridgeERC20({ _isLegacy: true, _l2Token: address(L2Token) });
         l2StandardBridge.withdraw(address(L2Token), 100, 1000, hex"");
 
@@ -281,7 +281,7 @@ contract L2StandardBridge_BridgeERC20_Test is PreBridgeERC20 {
     // - token is burned
     // - emits WithdrawalInitiated
     // - calls Withdrawer.initiateWithdrawal
-    function test_bridgeERC20_succeeds() external {
+    function skip_test_bridgeERC20_succeeds() external {
         _preBridgeERC20({ _isLegacy: false, _l2Token: address(L2Token) });
         l2StandardBridge.bridgeERC20(address(L2Token), address(L1Token), 100, 1000, hex"");
 
@@ -294,14 +294,14 @@ contract L2StandardBridge_BridgeERC20_Test is PreBridgeERC20 {
         l2StandardBridge.bridgeERC20(address(L2Token), address(BadL1Token), 100, 1000, hex"");
     }
 
-    function test_withdrawLegacyERC20_succeeds() external {
+    function skip_test_withdrawLegacyERC20_succeeds() external {
         _preBridgeERC20({ _isLegacy: true, _l2Token: address(LegacyL2Token) });
         l2StandardBridge.withdraw(address(LegacyL2Token), 100, 1000, hex"");
 
         assertEq(L2Token.balanceOf(alice), 0);
     }
 
-    function test_bridgeLegacyERC20_succeeds() external {
+    function skip_test_bridgeLegacyERC20_succeeds() external {
         _preBridgeERC20({ _isLegacy: false, _l2Token: address(LegacyL2Token) });
         l2StandardBridge.bridgeERC20(address(LegacyL2Token), address(L1Token), 100, 1000, hex"");
 
@@ -401,7 +401,7 @@ contract PreBridgeERC20To is CommonTest {
 contract L2StandardBridge_BridgeERC20To_Test is PreBridgeERC20To {
     /// @dev Tests that `withdrawTo` burns the tokens, emits `WithdrawalInitiated`,
     ///      and initiates a withdrawal with `Withdrawer.initiateWithdrawal`.
-    function test_withdrawTo_withdrawingERC20_succeeds() external {
+    function skip_test_withdrawTo_withdrawingERC20_succeeds() external {
         _preBridgeERC20To({ _isLegacy: true, _l2Token: address(L2Token) });
         l2StandardBridge.withdrawTo(address(L2Token), bob, 100, 1000, hex"");
 
@@ -410,7 +410,7 @@ contract L2StandardBridge_BridgeERC20To_Test is PreBridgeERC20To {
 
     /// @dev Tests that `bridgeERC20To` burns the tokens, emits `WithdrawalInitiated`,
     ///      and initiates a withdrawal with `Withdrawer.initiateWithdrawal`.
-    function test_bridgeERC20To_succeeds() external {
+    function skip_test_bridgeERC20To_succeeds() external {
         _preBridgeERC20To({ _isLegacy: false, _l2Token: address(L2Token) });
         l2StandardBridge.bridgeERC20To(address(L2Token), address(L1Token), bob, 100, 1000, hex"");
         assertEq(L2Token.balanceOf(alice), 0);
@@ -445,7 +445,7 @@ contract L2StandardBridge_Bridge_Test is CommonTest {
     }
 
     /// @dev Tests that bridging ETH succeeds.
-    function testFuzz_bridgeETH_succeeds(uint256 _value, uint32 _minGasLimit, bytes calldata _extraData) external {
+    function skip_testFuzz_bridgeETH_succeeds(uint256 _value, uint32 _minGasLimit, bytes calldata _extraData) external {
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
 
         bytes memory message = abi.encodeCall(IStandardBridge.finalizeBridgeETH, (alice, alice, _value, _extraData));
@@ -478,7 +478,7 @@ contract L2StandardBridge_Bridge_Test is CommonTest {
     }
 
     /// @dev Tests that bridging ETH to a different address succeeds.
-    function testFuzz_bridgeETHTo_succeeds(uint256 _value, uint32 _minGasLimit, bytes calldata _extraData) external {
+    function skip_testFuzz_bridgeETHTo_succeeds(uint256 _value, uint32 _minGasLimit, bytes calldata _extraData) external {
         uint256 nonce = l2CrossDomainMessenger.messageNonce();
 
         vm.expectCall(

--- a/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2ToL1MessagePasser.t.sol
@@ -11,7 +11,7 @@ import { Hashing } from "src/libraries/Hashing.sol";
 contract L2ToL1MessagePasserTest is CommonTest {
     /// @dev Tests that `initiateWithdrawal` succeeds and correctly sets the state
     ///      of the message passer for the withdrawal hash.
-    function testFuzz_initiateWithdrawal_succeeds(
+    function skip_testFuzz_initiateWithdrawal_succeeds(
         address _sender,
         address _target,
         uint256 _value,
@@ -49,7 +49,7 @@ contract L2ToL1MessagePasserTest is CommonTest {
 
     /// @dev Tests that `initiateWithdrawal` succeeds and emits the correct MessagePassed
     ///      log when called by a contract.
-    function testFuzz_initiateWithdrawal_fromContract_succeeds(
+    function skip_testFuzz_initiateWithdrawal_fromContract_succeeds(
         address _target,
         uint256 _gasLimit,
         uint256 _value,
@@ -79,7 +79,7 @@ contract L2ToL1MessagePasserTest is CommonTest {
 
     /// @dev Tests that `initiateWithdrawal` succeeds and emits the correct MessagePassed
     ///      log when called by an EOA.
-    function testFuzz_initiateWithdrawal_fromEOA_succeeds(
+    function skip_testFuzz_initiateWithdrawal_fromEOA_succeeds(
         uint256 _gasLimit,
         address _target,
         uint256 _value,
@@ -107,7 +107,7 @@ contract L2ToL1MessagePasserTest is CommonTest {
     }
 
     /// @dev Tests that `burn` succeeds and destroys the ETH held in the contract.
-    function testFuzz_burn_succeeds(uint256 _value, address _target, uint256 _gasLimit, bytes memory _data) external {
+    function skip_testFuzz_burn_succeeds(uint256 _value, address _target, uint256 _gasLimit, bytes memory _data) external {
         vm.deal(address(this), _value);
 
         l2ToL1MessagePasser.initiateWithdrawal{ value: _value }({ _target: _target, _gasLimit: _gasLimit, _data: _data });

--- a/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
+++ b/packages/contracts-bedrock/test/L2/OptimismSuperchainERC20.t.sol
@@ -190,7 +190,7 @@ contract OptimismSuperchainERC20Test is Test {
     }
 
     /// @notice Tests the `burn` burns the amount and emits the `Burn` event.
-    function testFuzz_burn_succeeds(address _from, uint256 _amount) public {
+    function skip_testFuzz_burn_succeeds(address _from, uint256 _amount) public {
         // Ensure `_from` is not the zero address
         vm.assume(_from != ZERO_ADDRESS);
 

--- a/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
+++ b/packages/contracts-bedrock/test/L2/SequencerFeeVault.t.sol
@@ -56,7 +56,7 @@ contract SequencerFeeVault_Test is CommonTest {
     }
 
     /// @dev Tests that `withdraw` successfully initiates a withdrawal to L1.
-    function test_withdraw_toL1_succeeds() external {
+    function skip_test_withdraw_toL1_succeeds() external {
         uint256 amount = sequencerFeeVault.MIN_WITHDRAWAL_AMOUNT() + 1;
         vm.deal(address(sequencerFeeVault), amount);
 

--- a/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/invariants/OptimismPortal2.t.sol
@@ -165,7 +165,7 @@ contract OptimismPortal2_Deposit_Invariant is CommonTest {
     ///
     ///                   All deposits, barring creation transactions and transactions
     ///                   sent to `address(0)`, should always succeed.
-    function invariant_deposit_completes() external view {
+    function skip_invariant_deposit_completes() external view {
         assertEq(actor.failedToComplete(), false);
     }
 }


### PR DESCRIPTION
Bridge function was simply turned off, but this also disables forced txs.

We needed to take another look at those contracts to figure out a way to achieve forced txs while still turning off native bridging functionality.

Removing the current require in `OptimismPortal2.sol` and replacing it with a check to see if:

- msg.value == 0 (to disallow bridging ETH)
- msg.sender != StandardBridge (block ERC20 bridging)
- msg.sender != ERC721Bridge (block NFT bridging)

does the trick.

Inside `packages/contracts-bedrock`, run
`forge test --match-test depositTransaction` 
to test the new behaviour.